### PR TITLE
Cast away class constness before calling toString

### DIFF
--- a/dmocks/dynamic.d
+++ b/dmocks/dynamic.d
@@ -62,7 +62,15 @@ class DynamicT(T) : Dynamic
     ///
     override string toString()
     {
-        return _data.to!string();
+        alias DataType = typeof(_data);
+        static if (is(DataType == class) && !hasFunctionAttributes!(DataType.toString, "const"))
+        {
+            return (cast(Unqual!DataType) _data).toString();
+        }
+        else
+        {
+            return _data.to!string;
+        }
     }
 
     /// two dynamics are equal when they store same type and the values pass opEquals
@@ -163,4 +171,10 @@ version (DMocksTest) {
         d.get!D;
     }
     +/
+
+    // Compiles with a const object with the mutable toString.
+    unittest
+    {
+        auto d = dynamic(new const Object);
+    }
 }

--- a/dmocks/dynamic.d
+++ b/dmocks/dynamic.d
@@ -62,10 +62,9 @@ class DynamicT(T) : Dynamic
     ///
     override string toString()
     {
-        alias DataType = typeof(_data);
-        static if (is(DataType == class) && !hasFunctionAttributes!(DataType.toString, "const"))
+        static if (is(typeof(_data) == class) && !hasFunctionAttributes!(typeof(_data).toString, "const"))
         {
-            return (cast(Unqual!DataType) _data).toString();
+            return (cast(Unqual!(typeof(_data))) _data).toString();
         }
         else
         {
@@ -172,9 +171,10 @@ version (DMocksTest) {
     }
     +/
 
-    // Compiles with a const object with the mutable toString.
+    // supports const object with non-const toString
     unittest
     {
-        auto d = dynamic(new const Object);
+        static assert(is(typeof(dynamic(new const Object))));
+        static assert(is(typeof(dynamic(new immutable Object))));
     }
 }


### PR DESCRIPTION
```d
module Foo;
import dmocks.mocks;

interface I
{
    public void doSometing(const Object o);
}

void test()
{
    auto mocker = new Mocker;
    I i = mocker.mock!I;
}
```