### PR TITLE
Fix error for const return types

### DIFF
--- a/dmocks/action.d
+++ b/dmocks/action.d
@@ -2,6 +2,7 @@ module dmocks.action;
 
 import dmocks.util;
 import dmocks.dynamic;
+import std.traits;
 
 package:
 
@@ -38,7 +39,7 @@ struct ReturnOrPass (T)
 {
     static if (!is (T == void))
     {
-        T value;
+        Unqual!T value;
     }
 
     bool pass;
@@ -83,14 +84,14 @@ struct Actor
         {
             if (self.returnValue !is null)
             {
-                rope.value = self.returnValue().get!(TReturn);
+                rope.value = self.returnValue().get!(Unqual!TReturn);
             }
             else if (self.action !is null)
             {
                 debugLog("action found, type: %s", self.action().type);
                 if (self.action().type == typeid(TReturn delegate(ArgTypes)))
                 {
-                    rope.value = self.action().get!(TReturn delegate(ArgTypes))()(args);
+                    rope.value = self.action().get!(Unqual!TReturn delegate(ArgTypes))()(args);
                 }
                 else
                 {


### PR DESCRIPTION
The case that fails:

```d
interface View
{
    const(string[][size_t]) myFunction();
}

unittest
{
    auto mocker = new Mocker();
    auto view = mocker.mock!View;

    mocker.expect(view.myFunction()).returns(null);

    mocker.replay();

    view.myFunction();

    mocker.verify();
}
```

> ../../dmocks/action.d(86,17): Error: cannot modify const expression rope.value
> ../../dmocks/action.d(93,21): Error: cannot modify const expression rope.value
> ../../dmocks/repository.d(127,65): Error: template instance dmocks.action.Actor.act!(const(string[][ulong])) error instantiating
> ../../dmocks/object_mock.d(127,73):        instantiated from here: MethodCall!(myFunction)
> ../../dmocks/object_mock.d-mixin-30(31,193):        instantiated from here: mockMethodCall!(myFunction, "myFunction", View, Mocked!(View), MockRepository, const(string[][ulong]) delegate(TypeInfo[], void*) pure nothrow @nogc @safe)
> ../../dmocks/factory.d(15,5):        instantiated from here: Mocked!(View)
> ../../dmocks/mocks.d(106,43):        instantiated from here: mock!(View)
source/app.d(43,23):        instantiated from here: mock!(View)
> ../../dmocks/repository.d(127,9): Error: cannot modify struct rope ReturnOrPass!(const(string[][ulong])) with immutable members
> ../../dmocks/object_mock.d(127,9): Error: cannot modify struct rope ReturnOrPass!(const(string[][ulong])) with immutable members