### PR TITLE
work around dmd linux bug where variadic methods in classes don't work.

### DIFF
--- a/dmocks/object_mock.d
+++ b/dmocks/object_mock.d
@@ -1,5 +1,7 @@
 module dmocks.object_mock;
 
+import core.vararg;
+
 import dmocks.util;
 import dmocks.repository;
 import dmocks.method_mock;


### PR DESCRIPTION
They just don't work. This makes them work. Not needed on Windows, not needed on LDC, but doesn't hurt either.